### PR TITLE
Switching default port to 9766

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The image name is provided as a query parameter when querying the exporter,
 and Prometheus-format metrics are returned, like this:
 
 ```console
-$ curl http://localhost:9764/limits?image=hairyhenderson/gomplate:v3.8.0
+$ curl http://localhost:9766/limits?image=hairyhenderson/gomplate:v3.8.0
 # HELP dockerhub_ratelimits_limit total number of pulls that can be performed during the window
 # TYPE dockerhub_ratelimits_limit gauge
 dockerhub_ratelimits_limit{image="hairyhenderson/gomplate:v3.8.0"} 100
@@ -53,7 +53,7 @@ scrape_configs:
         - prom/prometheus:v2.22.1
     static_configs:
       - targets:
-        - localhost:9764
+        - localhost:9766
 ```
 
 ## License

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func main() {
 		},
 	}
 
-	cmd.Flags().String("web.listen-address", ":9764", "Address at which to listen")
+	cmd.Flags().String("web.listen-address", ":9766", "Address at which to listen")
 
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
As allocated on https://github.com/prometheus/prometheus/wiki/Default-port-allocations

Signed-off-by: Dave Henderson <dhenderson@gmail.com>